### PR TITLE
Use full api uri in skelenox

### DIFF
--- a/skelenox.py
+++ b/skelenox.py
@@ -386,6 +386,7 @@ class SkelConnection(object):
             Prepare a standard API endpoint
         """
         endpoint = self.remote_path
+        endpoint += "/api/1.0/samples/"
         endpoint += str(self.sample_id)
         endpoint += "/" + submodule + "/"
         return endpoint

--- a/skelenox.py
+++ b/skelenox.py
@@ -381,12 +381,12 @@ class SkelConnection(object):
         print endpoint
         return False
 
-    def prepare_endpoint(self, submodule):
+    def prepare_endpoint(self, submodule, version="1.0"):
         """
             Prepare a standard API endpoint
         """
         endpoint = self.remote_path
-        endpoint += "/api/1.0/samples/"
+        endpoint += "/api/" + version + "/samples/"
         endpoint += str(self.sample_id)
         endpoint += "/" + submodule + "/"
         return endpoint


### PR DESCRIPTION
/api/1.0/samples/ were missing in prepare_endpoint.
It's not in config file as it seems that api version is much more
tied to skelenox code.

We could add API version as a paramater to prepare_endpoint so skelenox
could use different version of the API.