### PR TITLE
Adding font customization for the notepad

### DIFF
--- a/poli/views/webui.py
+++ b/poli/views/webui.py
@@ -187,6 +187,8 @@ def dl_skelenox():
         skel_config["save_timeout"] = 10 * 60
         skel_config["sync_frequency"] = 1.0 * 100
         skel_config["debug_level"] = "info"
+        skel_config["notepad_font_name"] = "Courier New"
+        skel_config["notepad_font_size"] = 9
         skel_json = json.dumps(skel_config, sort_keys=True, indent=4)
         myzip.writestr("skelsettings.json", skel_json)
         myzip.close()

--- a/skelenox.py
+++ b/skelenox.py
@@ -951,6 +951,10 @@ class SkelNotePad(QtWidgets.QWidget):
         label.setText("Notes about sample %s" % GetInputMD5())
 
         self.editor = QtWidgets.QTextEdit()
+
+        self.editor.setFontFamily(self.skel_settings.notepad_font_name)
+        self.editor.setFontPointSize(self.skel_settings.notepad_font_size)
+
         text = self.skel_conn.get_abstract()
         self.editor.setPlainText(text)
 


### PR DESCRIPTION
Notepad font family and size can be customized per user in the `skelsettings.json` config file.