### PR TITLE
[IMP] send batch of names/comments instead of 1 by 1

### DIFF
--- a/polichombr/views/api_idaactions.py
+++ b/polichombr/views/api_idaactions.py
@@ -103,17 +103,23 @@ def api_post_sample_comments(sid):
     data = request.json
     if "address" not in list(data.keys()) or "comment" not in list(data.keys()):
         abort(400, "Missing comment or address arguments")
-    address = data['address']
-    comment = data['comment']
+    data = request.json
+    addresses = data['address']
+    comments = data['comment']
     user_id = current_user.id
-    current_app.logger.debug(
-        "Getting a new comment for sample %d : %s@0x%x",
-        sid,
-        comment,
-        address)
-    action_id = api.idacontrol.add_comment(address, comment, user_id)
-    result = api.samplecontrol.add_idaaction(sid, action_id)
-    return jsonify({'result': result})
+    results = [] 
+    for i in range(len(addresses)) :
+        address = addresses[i]
+        comment = comments[i]
+        current_app.logger.debug(
+            "Getting a new comment for sample %d : %s@0x%x",
+            sid,
+            comment,
+            address)
+        action_id = api.idacontrol.add_comment(address, comment, user_id)
+        result = api.samplecontrol.add_idaaction(sid, action_id)
+        results.append(result)
+    return jsonify({'result': results})
 
 
 @apiview.route('/samples/<int:sid>/names/', methods=['GET'])
@@ -140,21 +146,26 @@ def api_post_sample_names(sid):
         @arg name the name
     """
     data = request.json
-    addr = data['address']
-    name = data['name']
+    addresses = data['address']
+    names = data['name']
     user_id = current_user.id
-    current_app.logger.debug(
-        "Getting a new name for sample %d : %s@0x%x",
-        sid,
-        name,
-        addr)
-    action_id = api.idacontrol.add_name(addr, name, user_id)
-    result = api.samplecontrol.add_idaaction(sid, action_id)
-    if result is True:
-        api.samplecontrol.rename_func_from_action(sid, addr, name)
+    results = [] 
+    for i in range(len(addresses)) :
+        name = names[i]
+        addr = addresses[i]
+        current_app.logger.debug(
+            "Getting a new name for sample %d : %s@0x%x",
+            sid,
+            name,
+            addr)
+        action_id = api.idacontrol.add_name(addr, name, user_id)
+        result = api.samplecontrol.add_idaaction(sid, action_id)
+        results.append(result)
+        if result is True:
+            api.samplecontrol.rename_func_from_action(sid, addr, name)
         # we don't care if the function is renamed for a global name,
         # so if the name is created return True anyway
-    return jsonify({'result': result})
+    return jsonify({'result': results})
 
 
 @apiview.route('/samples/<int:sid>/types/', methods=['POST'])

--- a/skelenox_plugin/connection.py
+++ b/skelenox_plugin/connection.py
@@ -268,6 +268,26 @@ class SkelIDAConnection(SkelConnection):
             logger.error("Cannot send comment %s ( 0x%x )", comment, address)
         return res["result"]
 
+    def push_comments(self, addresses=0, comments=None):
+        """
+            Push a standard comment
+        """
+        if comments is None or addresses == 0:
+            return False
+        data = {'address':[], 'comment':[]}
+        for address in addresses :
+            data['address'].append(address)
+        for comment in comments :
+            data['comment'].append(comment)
+        endpoint = self.prepare_endpoint('comments')
+        res = self.poli_post(endpoint, data)
+        if res["result"]:
+            logger.debug(
+                "Comments sent")
+        else:
+            logger.error("Cannot send comments")
+        return res["result"]
+
     def push_type(self, address, mtype=None):
         """
             Push defined types, parsed with prepare_parse_type
@@ -340,6 +360,27 @@ class SkelIDAConnection(SkelConnection):
             logger.debug("sent name %s at 0x%x", name, address)
         else:
             logger.error("failed to send name %s", name)
+        return True
+
+    def push_names(self, addresses=0, names=None):
+        """
+            Send a define name, be it func or area
+        """
+        if names is None:
+            return False
+        
+        data = {'address':[], 'name':[]}
+        for address in addresses :
+            data['address'].append(address)
+        for name in names :
+            data['name'].append(name)
+        #data = list(map(lambda x, y: {'address':x, 'name':y}, addresses, names))
+        endpoint = self.prepare_endpoint('names')
+        res = self.poli_post(endpoint, data)
+        if res["result"]:
+            logger.debug("sent names")
+        else:
+            logger.error("failed to send names")
         return True
 
     def create_struct(self, struct_name):

--- a/skelenox_plugin/core.py
+++ b/skelenox_plugin/core.py
@@ -94,18 +94,28 @@ class SkelCore(object):
             Used to send all the names to the server.
             Usecase: Previously analyzed IDB
         """
+        addresses = []
+        names = []
         for head in idautils.Names():
             if not idaapi.has_dummy_name(idaapi.get_flags(head[0])):
-                self.skel_conn.push_name(head[0], head[1])
+                addresses.append(head[0])
+                names.append(head[1])
+        if len(names) > 0:
+            self.skel_conn.push_names(addresses, names)
 
     def send_comments(self):
         """
             Initial sync of comments
         """
+        comments = []
+        heads = []
         for head in idautils.Heads():
             cmt = SkelUtils.get_comment(head)
             if cmt:
-                self.skel_conn.push_comment(head, cmt)
+                heads.append(head)
+                comments.append(cmt)
+        if len(comments) > 0:
+            self.skel_conn.push_comments(heads, comments)
 
     def run(self):
         """

--- a/skelenox_plugin/hooks.py
+++ b/skelenox_plugin/hooks.py
@@ -35,7 +35,7 @@ class SkelIDBHook(ida_idp.IDB_Hooks):
             Function comments are Area comments
         """
         cb, area, cmt, rpt = args
-        self.skel_conn.push_comment(area.startEA, cmt)
+        self.skel_conn.push_comments([area.startEA], [cmt])
 
         return ida_idp.IDB_Hooks.area_cmt_changed(self, *args)
 
@@ -51,7 +51,7 @@ class SkelIDBHook(ida_idp.IDB_Hooks):
                 auto = idaapi.has_auto_name(idaapi.get_flags(ea))
                 dummy = idaapi.has_dummy_name(idaapi.get_flags(ea))
                 if not dummy and not auto:
-                    self.skel_conn.push_name(ea, new_name)
+                    self.skel_conn.push_names([ea], [new_name])
         else:
             logger.warning("ea outside program...")
 
@@ -66,7 +66,7 @@ class SkelIDBHook(ida_idp.IDB_Hooks):
                      addr, rpt)
         cmt = idc.get_cmt(addr, rpt)
         if not SkelUtils.filter_coms_blacklist(cmt):
-            self.skel_conn.push_comment(addr, cmt)
+            self.skel_conn.push_comments([addr], [cmt])
         return ida_idp.IDB_Hooks.cmt_changed(self, *args)
 
     def gen_regvar_def(self, *args):


### PR DESCRIPTION
Hi,

The code in skelenox and on the server side has been improved, in order to send a batch of names and comments per POST when skelenox starts, instead of one per POST request. Even if it is still quite long, it considerably reduces the first early actions of this IDA Python script. 
For now, I kept the methods push_name and push_comment of the SkelIDAConnection class and created the methods push_names and push_comments in order to send the whole thing at once. The script api_idaactions has been adapted to handle lists of values. I think the former methods could be removed for the 2.0.

I will probably update the tests scripts too.